### PR TITLE
fix(home): featured video embeds fill card on large screens

### DIFF
--- a/src/components/landing-page/VideoCard.js
+++ b/src/components/landing-page/VideoCard.js
@@ -1,21 +1,27 @@
 import { extractYouTubeVideoId } from '@/utils/video_util';
-import { YouTubeEmbed } from '@next/third-parties/google';
 
 export default function VideoCard({ title, description, url }) {
   const youtubeVideoId = extractYouTubeVideoId(url);
+  const embedSrc = youtubeVideoId
+    ? `https://www.youtube.com/embed/${youtubeVideoId}?rel=0`
+    : null;
 
   return (
     <div className="bg-white rounded-2xl overflow-hidden shadow-sm h-full">
-      {/* YouTube Player */}
-      <div className="relative aspect-video bg-gray-900">
-        {youtubeVideoId ? (
-          <YouTubeEmbed videoid={youtubeVideoId} params="rel=0" />
+      <div className="relative aspect-video w-full overflow-hidden bg-black">
+        {embedSrc ? (
+          <iframe
+            title={title}
+            className="absolute inset-0 h-full w-full border-0"
+            src={embedSrc}
+            loading="lazy"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowFullScreen
+            referrerPolicy="strict-origin-when-cross-origin"
+          />
         ) : (
           // Fallback to native HTML video for non-YouTube URLs
-          <video
-            className="w-full h-full object-cover"
-            controls
-          >
+          <video className="absolute inset-0 h-full w-full object-cover" controls>
             <source src={url} type="video/mp4" />
             Your browser does not support the video tag.
           </video>

--- a/src/components/landing-page/VideoCard.js
+++ b/src/components/landing-page/VideoCard.js
@@ -1,26 +1,23 @@
 import { extractYouTubeVideoId } from '@/utils/video_util';
+import { YouTubeEmbed } from '@next/third-parties/google';
 
 export default function VideoCard({ title, description, url }) {
   const youtubeVideoId = extractYouTubeVideoId(url);
-  const embedSrc = youtubeVideoId
-    ? `https://www.youtube.com/embed/${youtubeVideoId}?rel=0`
-    : null;
 
   return (
-    <div className="bg-white rounded-2xl overflow-hidden shadow-sm h-full">
+    <div className="bg-white rounded-2xl overflow-hidden shadow-sm h-full min-w-0">
       <div className="relative aspect-video w-full overflow-hidden bg-black">
-        {embedSrc ? (
-          <iframe
-            title={title}
-            className="absolute inset-0 h-full w-full border-0"
-            src={embedSrc}
-            loading="lazy"
-            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-            allowFullScreen
-            referrerPolicy="strict-origin-when-cross-origin"
-          />
+        {youtubeVideoId ? (
+          <div
+            className="absolute inset-0 [&>*]:!absolute [&>*]:!inset-0 [&>*]:!h-full [&>*]:!w-full [&_lite-youtube]:block [&_lite-youtube]:!h-full [&_lite-youtube]:!w-full [&_lite-youtube]:!max-w-none"
+          >
+            <YouTubeEmbed
+              videoid={youtubeVideoId}
+              params="rel=0"
+              style="width:100%;height:100%"
+            />
+          </div>
         ) : (
-          // Fallback to native HTML video for non-YouTube URLs
           <video className="absolute inset-0 h-full w-full object-cover" controls>
             <source src={url} type="video/mp4" />
             Your browser does not support the video tag.

--- a/tests/components/VideoCard.test.js
+++ b/tests/components/VideoCard.test.js
@@ -1,15 +1,6 @@
 import VideoCard from '@/components/landing-page/VideoCard';
 import { render, screen } from '@testing-library/react';
 
-// Mock YouTubeEmbed component
-jest.mock('@next/third-parties/google', () => ({
-  YouTubeEmbed: ({ videoid, params }) => (
-    <div data-testid="mock-youtube-embed" data-videoid={videoid} data-params={params}>
-      YouTube Player: {videoid}
-    </div>
-  ),
-}));
-
 const defaultProps = {
   title: 'Test Video Title',
   description: 'This is a test video description that explains the content of the video.',
@@ -36,12 +27,15 @@ describe('VideoCard', () => {
     expect(container).toMatchSnapshot();
   });
 
-  it('renders a YouTube embed for YouTube URLs', () => {
+  it('renders a YouTube iframe for YouTube URLs', () => {
     render(<VideoCard {...defaultProps} />);
 
-    const youtubeEmbed = screen.getByTestId('mock-youtube-embed');
-    expect(youtubeEmbed).toHaveAttribute('data-videoid', 'dQw4w9WgXcQ');
-    expect(youtubeEmbed).toHaveAttribute('data-params', 'rel=0');
+    const iframe = screen.getByTitle('Test Video Title');
+    expect(iframe.tagName).toBe('IFRAME');
+    expect(iframe).toHaveAttribute(
+      'src',
+      'https://www.youtube.com/embed/dQw4w9WgXcQ?rel=0'
+    );
   });
 
   it('renders an HTML5 video for non-YouTube URLs', () => {
@@ -72,8 +66,11 @@ describe('VideoCard', () => {
         <VideoCard title="YouTube Video" description="Video" url={url} />
       );
 
-      const youtubeEmbed = screen.getByTestId('mock-youtube-embed');
-      expect(youtubeEmbed).toHaveAttribute('data-videoid', 'dQw4w9WgXcQ');
+      const iframe = screen.getByTitle('YouTube Video');
+      expect(iframe).toHaveAttribute(
+        'src',
+        expect.stringContaining('embed/dQw4w9WgXcQ')
+      );
 
       unmount();
     }

--- a/tests/components/VideoCard.test.js
+++ b/tests/components/VideoCard.test.js
@@ -1,6 +1,14 @@
 import VideoCard from '@/components/landing-page/VideoCard';
 import { render, screen } from '@testing-library/react';
 
+jest.mock('@next/third-parties/google', () => ({
+  YouTubeEmbed: ({ videoid, params, style }) => (
+    <div data-testid="mock-youtube-embed" data-videoid={videoid} data-params={params} data-style={style}>
+      YouTube Player: {videoid}
+    </div>
+  ),
+}));
+
 const defaultProps = {
   title: 'Test Video Title',
   description: 'This is a test video description that explains the content of the video.',
@@ -27,15 +35,13 @@ describe('VideoCard', () => {
     expect(container).toMatchSnapshot();
   });
 
-  it('renders a YouTube iframe for YouTube URLs', () => {
+  it('renders YouTubeEmbed for YouTube URLs', () => {
     render(<VideoCard {...defaultProps} />);
 
-    const iframe = screen.getByTitle('Test Video Title');
-    expect(iframe.tagName).toBe('IFRAME');
-    expect(iframe).toHaveAttribute(
-      'src',
-      'https://www.youtube.com/embed/dQw4w9WgXcQ?rel=0'
-    );
+    const embed = screen.getByTestId('mock-youtube-embed');
+    expect(embed).toHaveAttribute('data-videoid', 'dQw4w9WgXcQ');
+    expect(embed).toHaveAttribute('data-params', 'rel=0');
+    expect(embed).toHaveAttribute('data-style', 'width:100%;height:100%');
   });
 
   it('renders an HTML5 video for non-YouTube URLs', () => {
@@ -66,11 +72,8 @@ describe('VideoCard', () => {
         <VideoCard title="YouTube Video" description="Video" url={url} />
       );
 
-      const iframe = screen.getByTitle('YouTube Video');
-      expect(iframe).toHaveAttribute(
-        'src',
-        expect.stringContaining('embed/dQw4w9WgXcQ')
-      );
+      const embed = screen.getByTestId('mock-youtube-embed');
+      expect(embed).toHaveAttribute('data-videoid', 'dQw4w9WgXcQ');
 
       unmount();
     }
@@ -80,7 +83,14 @@ describe('VideoCard', () => {
     const { container } = render(<VideoCard {...defaultProps} />);
 
     const card = container.firstChild;
-    expect(card).toHaveClass('bg-white', 'rounded-2xl', 'overflow-hidden', 'shadow-sm', 'h-full');
+    expect(card).toHaveClass(
+      'bg-white',
+      'rounded-2xl',
+      'overflow-hidden',
+      'shadow-sm',
+      'h-full',
+      'min-w-0'
+    );
 
     const content = container.querySelector('.p-6.space-y-3');
     expect(content).toBeInTheDocument();

--- a/tests/components/__snapshots__/VideoCard.test.js.snap
+++ b/tests/components/__snapshots__/VideoCard.test.js.snap
@@ -6,16 +6,17 @@ exports[`VideoCard renders VideoCard with title and description 1`] = `
     class="bg-white rounded-2xl overflow-hidden shadow-sm h-full"
   >
     <div
-      class="relative aspect-video bg-gray-900"
+      class="relative aspect-video w-full overflow-hidden bg-black"
     >
-      <div
-        data-params="rel=0"
-        data-testid="mock-youtube-embed"
-        data-videoid="dQw4w9WgXcQ"
-      >
-        YouTube Player: 
-        dQw4w9WgXcQ
-      </div>
+      <iframe
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+        allowfullscreen=""
+        class="absolute inset-0 h-full w-full border-0"
+        loading="lazy"
+        referrerpolicy="strict-origin-when-cross-origin"
+        src="https://www.youtube.com/embed/dQw4w9WgXcQ?rel=0"
+        title="Test Video Title"
+      />
     </div>
     <div
       class="p-6 space-y-3"

--- a/tests/components/__snapshots__/VideoCard.test.js.snap
+++ b/tests/components/__snapshots__/VideoCard.test.js.snap
@@ -3,20 +3,24 @@
 exports[`VideoCard renders VideoCard with title and description 1`] = `
 <div>
   <div
-    class="bg-white rounded-2xl overflow-hidden shadow-sm h-full"
+    class="bg-white rounded-2xl overflow-hidden shadow-sm h-full min-w-0"
   >
     <div
       class="relative aspect-video w-full overflow-hidden bg-black"
     >
-      <iframe
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-        allowfullscreen=""
-        class="absolute inset-0 h-full w-full border-0"
-        loading="lazy"
-        referrerpolicy="strict-origin-when-cross-origin"
-        src="https://www.youtube.com/embed/dQw4w9WgXcQ?rel=0"
-        title="Test Video Title"
-      />
+      <div
+        class="absolute inset-0 [&>*]:!absolute [&>*]:!inset-0 [&>*]:!h-full [&>*]:!w-full [&_lite-youtube]:block [&_lite-youtube]:!h-full [&_lite-youtube]:!w-full [&_lite-youtube]:!max-w-none"
+      >
+        <div
+          data-params="rel=0"
+          data-style="width:100%;height:100%"
+          data-testid="mock-youtube-embed"
+          data-videoid="dQw4w9WgXcQ"
+        >
+          YouTube Player: 
+          dQw4w9WgXcQ
+        </div>
+      </div>
     </div>
     <div
       class="p-6 space-y-3"


### PR DESCRIPTION
This pull request refactors the `VideoCard` component to replace the use of the `YouTubeEmbed` component with a native `<iframe>` for embedding YouTube videos. It also updates the associated tests and snapshots to reflect this change, simplifying the rendering logic and removing the dependency on the third-party embed component.

**Component refactor:**
* Replaced the `YouTubeEmbed` component from `@next/third-parties/google` with a standard `<iframe>` for YouTube video embedding in `VideoCard`, and adjusted the markup for improved styling and accessibility.

**Test updates:**
* Removed the mock for `YouTubeEmbed` and updated tests to check for the presence and attributes of the `<iframe>` element instead of the mocked component in `VideoCard.test.js`. [[1]](diffhunk://#diff-212cf7ca0213f41f70c786738430717d8e1d655fe2bd208563aa8fd1cf38395dL4-L12) [[2]](diffhunk://#diff-212cf7ca0213f41f70c786738430717d8e1d655fe2bd208563aa8fd1cf38395dL39-R38) [[3]](diffhunk://#diff-212cf7ca0213f41f70c786738430717d8e1d655fe2bd208563aa8fd1cf38395dL75-R73)
* Updated test snapshots to match the new rendered output with the `<iframe>` structure.
