### PR TITLE
Hero: use uniform 36px padding on homepage media block

### DIFF
--- a/src/components/landing-page/HeroMediaBlock.js
+++ b/src/components/landing-page/HeroMediaBlock.js
@@ -3,7 +3,7 @@ import HeroTitle from './HeroTitle';
 
 export default function HeroMediaBlock({ title, description, heroAlt }) {
   return (
-    <div className="relative pt-8 pb-8 px-4 md:px-20 overflow-hidden rounded-lg min-h-[500px] md:min-h-[600px] ">
+    <div className="relative p-[36px] overflow-hidden rounded-lg min-h-[500px] md:min-h-[600px] ">
       <div className="absolute inset-0 w-full h-full overflow-hidden">
         <HeroVideo alt={heroAlt} />
         <div className="absolute inset-0 bg-black/20 z-20" />

--- a/src/components/landing-page/HeroMediaBlock.js
+++ b/src/components/landing-page/HeroMediaBlock.js
@@ -3,7 +3,7 @@ import HeroTitle from './HeroTitle';
 
 export default function HeroMediaBlock({ title, description, heroAlt }) {
   return (
-    <div className="relative p-[36px] overflow-hidden rounded-lg min-h-[500px] md:min-h-[600px]">
+    <div className="relative p-9 overflow-hidden rounded-lg min-h-[500px] md:min-h-[600px]">
       <div className="absolute inset-0 w-full h-full overflow-hidden">
         <HeroVideo alt={heroAlt} />
         <div className="absolute inset-0 bg-black/20 z-20" />

--- a/src/components/landing-page/HeroMediaBlock.js
+++ b/src/components/landing-page/HeroMediaBlock.js
@@ -3,7 +3,7 @@ import HeroTitle from './HeroTitle';
 
 export default function HeroMediaBlock({ title, description, heroAlt }) {
   return (
-    <div className="relative p-[36px] overflow-hidden rounded-lg min-h-[500px] md:min-h-[600px] ">
+    <div className="relative p-[36px] overflow-hidden rounded-lg min-h-[500px] md:min-h-[600px]">
       <div className="absolute inset-0 w-full h-full overflow-hidden">
         <HeroVideo alt={heroAlt} />
         <div className="absolute inset-0 bg-black/20 z-20" />

--- a/tests/components/HeroSection.test.js
+++ b/tests/components/HeroSection.test.js
@@ -275,7 +275,7 @@ describe('HeroSection', () => {
     expect(buttonContainer).toBeInTheDocument();
 
     // Should have video container with correct styling
-    const videoContainer = container.querySelector('.relative.pt-8.pb-8');
+    const videoContainer = container.querySelector('.relative.p-\\[36px\\]');
     expect(videoContainer).toBeInTheDocument();
     expect(videoContainer).toHaveClass('overflow-hidden', 'rounded-lg');
   });

--- a/tests/components/HeroSection.test.js
+++ b/tests/components/HeroSection.test.js
@@ -275,7 +275,7 @@ describe('HeroSection', () => {
     expect(buttonContainer).toBeInTheDocument();
 
     // Should have video container with correct styling
-    const videoContainer = container.querySelector('[class~="relative"][class~="p-[36px]"]');
+    const videoContainer = container.querySelector('[class~="relative"][class~="p-9"]');
     expect(videoContainer).toBeInTheDocument();
     expect(videoContainer).toHaveClass('overflow-hidden', 'rounded-lg');
   });

--- a/tests/components/HeroSection.test.js
+++ b/tests/components/HeroSection.test.js
@@ -275,7 +275,7 @@ describe('HeroSection', () => {
     expect(buttonContainer).toBeInTheDocument();
 
     // Should have video container with correct styling
-    const videoContainer = container.querySelector('.relative.p-\\[36px\\]');
+    const videoContainer = container.querySelector('[class~="relative"][class~="p-[36px]"]');
     expect(videoContainer).toBeInTheDocument();
     expect(videoContainer).toHaveClass('overflow-hidden', 'rounded-lg');
   });


### PR DESCRIPTION
Sets the hero banner wrapper (HeroMediaBlock) to equal padding on all sides (36px) so the inset matches the design spec and DevTools no longer shows uneven horizontal vs vertical padding.

Changes
HeroMediaBlock: Replaced pt-8 pb-8 px-4 md:px-20 with p-[36px] on the outer hero container.
HeroSection.test.js: Updated the layout test selector so it still targets the hero media wrapper after the class change.

https://app.notion.com/p/WDR-Tracker-a5649d477bd68345824201d90a990a9d?p=35149d477bd680a98acecc98571817d3&pm=s

[https://app.notion.com/p/WDR-Tracker-a5649d477bd68345824201d90a990a9d?p=35149d477bd680a98acecc98571817d3&pm=s](https://app.notion.com/p/WDR-Tracker-a5649d477bd68345824201d90a990a9d?p=35149d477bd680a98acecc98571817d3&pm=s)